### PR TITLE
Defer to doorkeeper on invalid pre auth

### DIFF
--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -8,8 +8,7 @@ module Doorkeeper
           super.tap do |owner|
             next unless controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
               action_name == 'new'
-            raise Errors::OpenidConnectError unless pre_auth.valid?
-            next unless pre_auth.scopes.include?('openid')
+            next unless pre_auth.valid? && pre_auth.scopes.include?('openid')
 
             handle_prompt_param!(owner)
             handle_max_age_param!(owner)

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -6,21 +6,34 @@ module Doorkeeper
 
         def authenticate_resource_owner!
           super.tap do |owner|
-            next unless controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
-              action_name == 'new'
-            next unless pre_auth.valid? && pre_auth.scopes.include?('openid')
+            next unless valid_controller_path?
+            next unless scopes.include?('openid')
 
             handle_prompt_param!(owner)
             handle_max_age_param!(owner)
           end
         rescue Errors::OpenidConnectError => exception
+          handle_error(exception)
+        end
+
+        def valid_controller_path?
+          controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] && action_name == 'new'
+        end
+
+        def scopes
+          pre_auth.scopes
+        rescue NoMethodError
+          []
+        end
+
+        def handle_error(exception = nil)
           # clear the previous response body to avoid a DoubleRenderError
           self.response_body = nil
 
           # FIXME: workaround for Rails 5, see https://github.com/rails/rails/issues/25106
           @_response_body = nil
 
-          error_response = if pre_auth.valid?
+          error_response = if pre_auth.valid? && exception.present?
             ::Doorkeeper::OAuth::ErrorResponse.new(
               name: exception.error_name,
               state: params[:state],

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -264,9 +264,9 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
   end
 
   describe 'when params are missing' do
-    it 'responds with 4xx' do
+    it 'skips over the openid behavior' do
       authorize!({ scope: nil, current_user: nil, client_id: nil })
-      expect(response.status).to be(401)
+      expect(response.status).to be(302)
     end
   end
 end


### PR DESCRIPTION
Work around for using `pre_auth` when it's invalid and missing `client`, which causes doorkeeper's `pre_authorization` to attempt to access `application` off `client` and raising without being caught.

We'll tease apart the full intent of the author when we submit a formal PR to the OpenID Connect gem proper, because it feels like these uncaught exceptions should be a consistent, serious issue for the gem in general.

Are they assuming that `resource_owner_authenticator` will be validating and catching `pre_auth` before it gets to them?  That seems like an overreach of responsibility.