### PR TITLE
DO NOT MERGE: Check scope params for openid before we validate pre_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,5 +291,3 @@ Doorkeeper::OpenidConnect is released under the [MIT License](http://www.opensou
 ## Sponsors
 
 Initial development of this project was sponsored by [PlayOn! Sports](https://github.com/playon).
-
-Can I do this?

--- a/README.md
+++ b/README.md
@@ -291,3 +291,5 @@ Doorkeeper::OpenidConnect is released under the [MIT License](http://www.opensou
 ## Sponsors
 
 Initial development of this project was sponsored by [PlayOn! Sports](https://github.com/playon).
+
+Can I do this?

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -8,6 +8,7 @@ module Doorkeeper
           super.tap do |owner|
             next unless controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
               action_name == 'new'
+            raise Errors::OpenidConnectError unless pre_auth.valid?
             next unless pre_auth.scopes.include?('openid')
 
             handle_prompt_param!(owner)

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -8,8 +8,7 @@ module Doorkeeper
           super.tap do |owner|
             next unless controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
               action_name == 'new'
-            raise Errors::OpenidConnectError unless pre_auth.valid?
-            next unless pre_auth.scopes.include?('openid')
+            next unless pre_auth.valid? && pre_auth.scopes.include?('openid')
 
             handle_prompt_param!(owner)
             handle_max_age_param!(owner)

--- a/lib/doorkeeper/openid_connect/helpers/controller.rb
+++ b/lib/doorkeeper/openid_connect/helpers/controller.rb
@@ -6,21 +6,34 @@ module Doorkeeper
 
         def authenticate_resource_owner!
           super.tap do |owner|
-            next unless controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] &&
-              action_name == 'new'
-            next unless pre_auth.valid? && pre_auth.scopes.include?('openid')
+            next unless valid_controller_path?
+            next unless scopes.include?('openid')
 
             handle_prompt_param!(owner)
             handle_max_age_param!(owner)
           end
         rescue Errors::OpenidConnectError => exception
+          handle_error(exception)
+        end
+
+        def valid_controller_path?
+          controller_path == Doorkeeper::Rails::Routes.mapping[:authorizations][:controllers] && action_name == 'new'
+        end
+
+        def scopes
+          pre_auth.scopes
+        rescue NoMethodError
+          []
+        end
+
+        def handle_error(exception = nil)
           # clear the previous response body to avoid a DoubleRenderError
           self.response_body = nil
 
           # FIXME: workaround for Rails 5, see https://github.com/rails/rails/issues/25106
           @_response_body = nil
 
-          error_response = if pre_auth.valid?
+          error_response = if pre_auth.valid? && exception.present?
             ::Doorkeeper::OAuth::ErrorResponse.new(
               name: exception.error_name,
               state: params[:state],

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -262,4 +262,11 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
   end
+
+  describe 'when params are missing' do
+    it 'responds with 4xx' do
+      authorize!({ scope: nil, current_user: nil, client_id: nil })
+      expect(response.status).to be(401)
+    end
+  end
 end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -264,9 +264,9 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
   end
 
   describe 'when params are missing' do
-    it 'responds with 4xx' do
+    it 'skips over the openid behavior' do
       authorize!({ scope: nil, current_user: nil, client_id: nil })
-      expect(response.status).to be(401)
+      expect(response.status).to be(302)
     end
   end
 end

--- a/spec/controllers/doorkeeper/authorizations_controller_spec.rb
+++ b/spec/controllers/doorkeeper/authorizations_controller_spec.rb
@@ -269,4 +269,21 @@ describe Doorkeeper::AuthorizationsController, type: :controller do
       expect(response.status).to be(302)
     end
   end
+
+  describe 'with openid scope but missing response_type and client params' do
+    it 'returns an unsupported_response_type error' do
+      get :new, params: {
+        redirect_uri: application.redirect_uri,
+        scope: 'openid',
+      }
+
+      error_params = {
+        'error' => 'unsupported_response_type',
+        'error_description' => 'The authorization server does not support this response type.'
+      }
+
+      expect(response).to redirect_to build_redirect_uri(error_params)
+      expect(JSON.parse(response.body)).to eq(error_params)
+    end
+  end
 end


### PR DESCRIPTION
- OIDC Core 1.0 3.1.2.1 states that behavior is unspecified if the openid scope is missing.
  - By checking the openid scope on `pre_auth`, we're implicitly tying pre_auth validity to the check, which seems unnecessary.
  - Pre_auth validity is only something that must be true after we're going down the openid path, which is why we've also added that validation right after.
  - Given that openid scope missing behavior is unspecified, we deem that having base Doorkeeper handle the rest of the request by `next` skipping the rest of the block is appropriate, since Doorkeeper does validity checks and error handling.
- Remove some refactors which may not be strictly necessary
